### PR TITLE
Fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ['titanfp', 'titanfp.titanic', 'titanfp.fpbench', 'titanfp.arithmetic
 
 [project]
 name = "titanfp"
-version = "0.1.0"
+version = "0.1.1"
 description = "number systems research with FPBench, including implementation of posits"
 authors = [
     { name = "Bill Zorn", email = "billzorn@cs.washington.edu" },

--- a/titanfp/arithmetic/interpreter.py
+++ b/titanfp/arithmetic/interpreter.py
@@ -139,7 +139,7 @@ class Evaluator(object):
         ast.Tanh: '_eval_tanh',
         ast.Exp: '_eval_exp',
         ast.Exp2: '_eval_exp2',
-        ast.Expm1: '_eval_exmp1',
+        ast.Expm1: '_eval_expm1',
         ast.Log: '_eval_log',
         ast.Log10: '_eval_log10',
         ast.Log1p: '_eval_log1p',

--- a/titanfp/arithmetic/interpreter.py
+++ b/titanfp/arithmetic/interpreter.py
@@ -893,7 +893,7 @@ class StandardInterpreter(SimpleInterpreter):
 
     def _eval_exp(self, e, ctx):
         in0 = self.evaluate(e.children[0], ctx)
-        return [in0], in0.exp(ctx=ctx)
+        return [in0], in0.exp_(ctx=ctx)
 
     def _eval_exp2(self, e, ctx):
         in0 = self.evaluate(e.children[0], ctx)

--- a/titanfp/arithmetic/interpreter.py
+++ b/titanfp/arithmetic/interpreter.py
@@ -252,6 +252,11 @@ class BaseInterpreter(Evaluator):
     def _eval_val(self, e, ctx):
         return None, self.arg_to_digital(e.value, ctx)
 
+    def _eval_hexnum(self, e, ctx):
+        # older versions of gmpy2 are broken
+        value = e.value.replace('-0x', '0x-')
+        return None, self.arg_to_digital(value, ctx)
+
     def _eval_constant(self, e, ctx):
         try:
             return None, self.constants[e.value]


### PR DESCRIPTION
Adds new overflow/underflow exceptions. When any computed value exceeds MPFR's limits, gmpy2 was throwing an overflow/underflow exception. Unfortunately, we could not determine the sign of the too small (too large) value. This adds an exception type into Titanic that also includes the sign of the result.

```python
class SignedOverflow(...)
  ...
class SignedUnderflow(...)
  ...
```

Fixes a number of bugs:
- fixed typo `"_eval_exmp1"` -> `"_eval_expm1"` (could not compute `expm1`)
- fix typo `exp` -> `exp_` (could not compute `exp`)
- eliminate incorrect PrecisionError during integer rounding (MPFR does not produce a ternary!)
- could not evaluate negative hexnum values due to gmpy2 bug

Bumps version number of quick release.
